### PR TITLE
fix: remove sorted check for streams

### DIFF
--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -29,7 +29,6 @@ class TicketsStream(GorgiasStream):
     path = "/api/views/{view_id}/items"
     primary_keys = ["id"]
     replication_key = "updated_datetime"
-    is_sorted = True
 
     # Link to the next items, if any.
     next_page_token_jsonpath = "$.meta.next_items"


### PR DESCRIPTION
This will remove the setting of `is_sorted=True` on ticket streams to eliminate the sorted stream error that keeps happening with CPAP and Fairing. (This property value defaults to `false` within Meltano SDK if not specifically designated.) We handle sorting in BigQuery, so this check isn't necessary for Source Medium in the extraction step.